### PR TITLE
typo on expected object keys in exercise 24

### DIFF
--- a/index.html
+++ b/index.html
@@ -2871,7 +2871,7 @@ function() {
     
     <div class="lesson">
         <h4>Exercise 24: Retrieve each video's id, title, middle interesting moment time, and <i>smallest</i> box art url.</h4>
-        <p>This is a variation of the problem we solved earlier. This time each video has an interesting moments collection, each representing a time during which a screenshot is interesting or representative of the title as a whole. Notice that both the boxarts and interestingMoments arrays are located at the same depth in the tree. Retrieve the time of the middle interesting moment and the smallest box art url <i>simultaneously</i> with zip(). Return an {id, title, time, boxart} object for each video.</p>
+        <p>This is a variation of the problem we solved earlier. This time each video has an interesting moments collection, each representing a time during which a screenshot is interesting or representative of the title as a whole. Notice that both the boxarts and interestingMoments arrays are located at the same depth in the tree. Retrieve the time of the middle interesting moment and the smallest box art url <i>simultaneously</i> with zip(). Return an {id, title, time, url} object for each video.</p>
     <textarea class="code" rows="60" cols="80">
 function() {
     var movieLists = [


### PR DESCRIPTION
Alternately, change the expected data to have a "boxart" key instead of "url" key.