### PR TITLE
Fixing "verifier is not a function" error

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,7 +370,7 @@ var last = new Date();
                     codeMirrors.push(codeMirror);
                     go.onclick = function() {
                         try {
-                            var verifier = eval("(" + verifierScript.innerText + ")");
+                            var verifier = eval("(" + verifierScript.innerHTML + ")");
 
                             try {
                                 codeMirror.save();


### PR DESCRIPTION
Changed verifierScript.innerText to verifierScript.innerHTML in order to fix the "verifier is not a function" in Firefox.