### PR TITLE
Fix of innerText for FireFox

### DIFF
--- a/assets/app/main.js
+++ b/assets/app/main.js
@@ -49,7 +49,7 @@ window.onload = function() {
 			output = $(".output", item)[0],
 			code = $(".code", item)[0],
 			showAnswer = $(".showAnswer", item)[0],
-			answer = $(".answer", item)[0],
+			answer = $(".answer", item).text(),
 			codeMirror = CodeMirror.fromTextArea(code, {
 				lineNumbers: true,
 				matchBrackets: true,
@@ -66,13 +66,13 @@ window.onload = function() {
 				  }
 			}),
 			post = $(".post", item)[0],
-			verifierScript = $(".verifier", item)[0],
+			verifierScript = $(".verifier", item).text(),
 			controls = $(".control", item);
 
 		codeMirrors.push(codeMirror);
 		go.onclick = function() {
 			try {
-				var verifier = eval("(" + verifierScript.innerText + ")");
+				var verifier = eval("(" + verifierScript + ")");
 
 				try {
 					codeMirror.save();
@@ -96,7 +96,7 @@ window.onload = function() {
 
 		if (showAnswer) {
 			showAnswer.onclick = function() {
-				codeMirror.setValue(answer.innerText);
+				codeMirror.setValue(answer);
 			};
 		}
 	});

--- a/assets/app/utils.js
+++ b/assets/app/utils.js
@@ -307,20 +307,20 @@ window.showAllAnswers = function(upTo) {
 			code = $(".code", item)[0],
 			output = $(".output", item)[0],
 			showAnswer= $(".showAnswer", item)[0],
-			answer= $(".answer", item)[0],
+			answer= $(".answer", item).text(),
 			codeMirror = codeMirrors[cnt],
 			post = $(".post", item)[0],
-			verifierScript = $(".verifier", item)[0],
+			verifierScript = $(".verifier", item).text(),
 			controls = $(".control", item);
 
-		if (!answer || answer.innerText.length === 0){
+		if (answer.length === 0){
 			return;
 		}
 
-		codeMirror.setValue(answer.innerText);
+		codeMirror.setValue(answer);
 
 		try {
-			var verifier = eval("(" + verifierScript.innerText + ")");
+			var verifier = eval("(" + verifierScript + ")");
 
 			try {
 				codeMirror.save();


### PR DESCRIPTION
The **innerText** property is not in the standard and not supported by FireFox. Therefore, it wasn't possible to work with the lessons in FireFox. JQuery's text() method is a good cross-browser alternative.
See [this](http://stackoverflow.com/questions/1836942/difference-between-innertext-and-html) for details.