### PR TITLE
Fix to prevent 'undefined is not a function' like errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,43 @@
 	<link rel="stylesheet" href="assets/codemirror/codemirror.css">
 	<link rel="stylesheet" href="assets/app/site.css">
 	<title>Functional Programming in Javascript</title>
+	<script type="text/javascript">
+		// Adds the implementation for Array.prototype.concatAll()
+		function defineConcatAll() {
+			Array.prototype.concatAll = function () {
+				var results = [];
+
+				this.forEach(function(subArray) {
+					results.push.apply(results, subArray);
+				});
+
+				return results;
+			};
+		}
+
+		/**
+		 * Add the implementation for Array.prototype.concatMap()
+		 */
+		function defineConcatMap() {
+			Array.prototype.concatMap = function(fnc) {
+				return this.
+					map(function (e) {
+						return fnc(e);
+					}).
+					// apply the concatAll function to flatten the two-dimensional array
+					concatAll();
+			};
+		}
+
+		/**
+		 * This function will be executed at the begining of each verifier function
+		 */
+		function preVerifierHook() {
+			// Add helpers to prevent 'undefined is not a function' like errors
+			defineConcatAll();
+			defineConcatMap();
+		}
+	</script>
 </head>
 <body>
 <div class="content">
@@ -99,6 +136,7 @@
 		<pre class="verifier">
 			// Traverse array with for loop
 			function(str) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")");
 				var items = [];
 				var got;
@@ -158,6 +196,7 @@
 		<pre class="verifier">
 			// Traverse array with foreach
 			function(str) {
+				preVerifierHook();
 				if (str.indexOf(".forEach") === -1) {
 					return "You have to use forEach!"
 				}
@@ -264,6 +303,7 @@
 		<pre class="verifier">
 			// Projection with with forEach
 			function(str) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					videoAndTitlePairs = fun(),
 					expected = '[{\"id\":675465,\"title\":\"Fracture\"},{\"id\":65432445,\"title\":\"The Chamber\"},{\"id\":70111470,\"title\":\"Die Hard\"},{\"id\":654356453,\"title\":\"Bad Boys\"}]';
@@ -371,6 +411,7 @@
 		<pre class="verifier">
 			// Implement map()
 			function(str) {
+				preVerifierHook();
 				var fun = eval(str),
 					arr = [1,2,3],
 					result;
@@ -463,6 +504,7 @@
 		<pre class="verifier">
 			// Projection with map
 			function(str) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					videoAndTitlePairs = fun(),
 					expected = '[{\"id\":675465,\"title\":\"Fracture\"},{\"id\":65432445,\"title\":\"The Chamber\"},{\"id\":70111470,\"title\":\"Die Hard\"},{\"id\":654356453,\"title\":\"Bad Boys\"}]';
@@ -591,6 +633,7 @@
 		<pre class="verifier">
 			// Filter with forEach
 			function(str) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					videos = fun(),
 					expected = '[{"id":675465,"title":"Fracture","boxart":"http://cdn-0.nflximg.com/images/2891/Fracture.jpg","uri":"http://api.netflix.com/catalog/titles/movies/70111470","rating":5,"bookmark":[{"id":432534,"time":65876586}]},{"id":654356453,"title":"Bad Boys","boxart":"http://cdn-0.nflximg.com/images/2891/BadBoys.jpg","uri":"http://api.netflix.com/catalog/titles/movies/70111470","rating":5,"bookmark":[{"id":432534,"time":65876586}]}]';
@@ -699,6 +742,7 @@
 		<pre class="verifier">
 			// Implement filter()
 			function(str) {
+				preVerifierHook();
 				var fun = eval(str),
 					arr = [1,2,3],
 					result;
@@ -790,6 +834,7 @@
 		<pre class="verifier">
 			// Filter with filter()
 			function(str) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					videoids = fun(),
 					expected = '[675465,654356453]';
@@ -1049,6 +1094,7 @@
 		<pre class="verifier">
 			// Flatten movieLists into an array of video ids
 			function(str) {
+				preVerifierHook();
 				var fun = eval(str),
 					arr = [[1,2,3],[4,5,6],[7,8,9]],
 					result,
@@ -1147,6 +1193,7 @@
 
 		<pre class="verifier">
 			function(str) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					videos = fun(),
 					expected = '[675465,65432445,70111470,654356453]';
@@ -1329,6 +1376,7 @@
 
 		<pre class="verifier">
 			function(str) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					videos = fun(),
 					got,
@@ -1484,6 +1532,7 @@
 		<pre class="verifier">
 			// Implement concatAll
 			function(str) {
+				preVerifierHook();
 				var fun = eval(str),
 					spanishFrenchEnglishWords = [ ["cero","rien","zero"], ["uno","un","one"], ["dos","deux","two"] ],
 					allWords = [0,1,2],
@@ -1617,6 +1666,7 @@
 
 		<pre class="verifier">
 			function(str) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					videos = fun(),
 					got,
@@ -1775,6 +1825,7 @@
 		<pre class="verifier">
 			// Find largest box art
 			function(str){
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					boxart = fun(),
 					got = JSON.stringify(boxart),
@@ -1866,6 +1917,7 @@
 		<pre class="verifier">
 			// Implement reduce
 			function(str) {
+				preVerifierHook();
 				var fun = eval(str),
 					numbers = [1,2,3],
 					sum = numbers.reduce(function(acc,curr) { return acc + curr }),
@@ -1944,6 +1996,7 @@
 		<pre class="verifier">
 			 // Find largest rating
 			function(str){
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					boxarts = fun(),
 					got = JSON.stringify(boxarts),
@@ -2006,6 +2059,7 @@
 		<pre class="verifier">
 			// Find largest box art with reduce
 			function(str){
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					boxarts = fun(),
 					got = JSON.stringify(boxarts),
@@ -2122,6 +2176,7 @@
 		<pre class="verifier">
 			// Reducing with an initial value
 			function(str){
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					videoMap = fun()[0],
 					expected = [
@@ -2297,6 +2352,7 @@
 		<pre class="verifier">
 			// Find the id, title, and smallest box art.
 			function(str) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					videos = fun(),
 					got,
@@ -2474,6 +2530,7 @@
 		<pre class="verifier">
 			// Zip imperatively
 			function(str) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					pairs = fun(),
 					got,
@@ -2568,6 +2625,7 @@
 		<pre class="verifier">
 			// Implement zip
 			function(str) {
+				preVerifierHook();
 				var fun = eval(str),
 					left = [1,2,3],
 					right = [4,5,6],
@@ -2652,6 +2710,7 @@
 		<pre class="verifier">
 			// Combine videos and bookmarks
 			function(str) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					pairs = fun(),
 					got,
@@ -2815,6 +2874,7 @@
 		<pre class="verifier">
 			// Find id, title, smallest box art, and bookmark id
 			function(str) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					videos = fun(),
 					got,
@@ -3026,6 +3086,7 @@
         <pre class="verifier">
 			// Combine videos and bookmarks
 			function(str) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					pairs = fun(),
 					got,
@@ -3207,6 +3268,7 @@
 		<pre class="verifier">
 			// Combine videos and bookmarks
 			function(str) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					pairs = fun(),
 					got,
@@ -3358,6 +3420,7 @@
         <pre class="verifier">
 			// Combine videos and bookmarks
 			function(str, lesson) {
+				preVerifierHook();
 				var output = $(".output", lesson)[0],
 					fun = eval("(" + str + ")"),
 					stockSymbols = ["MSFT", "GOOG","NFLX","OSTK"],
@@ -3497,6 +3560,7 @@
 		<pre class="verifier">
 			// Combine videos and bookmarks 2
 			function(str, lesson) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					button = $('.button', lesson)[0];
 
@@ -3540,6 +3604,7 @@
 		<pre class="verifier">
 			// Combine videos and bookmarks 2
 			function(str, lesson) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					button = $('.button', lesson)[0];
 
@@ -3623,6 +3688,7 @@
 		<pre class="verifier">
 			// Combine videos and bookmarks 2
 			function(str, lesson) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					button = $('.button', lesson)[0];
 
@@ -3695,6 +3761,7 @@
 		<pre class="verifier">
 			// Combine videos and bookmarks 2
 			function(str, lesson) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					output = $(".output", lesson)[0],
 					stopButton = $('.stop', lesson)[0],
@@ -3928,6 +3995,7 @@
 		<pre class="verifier">
 			// Combine videos and bookmarks 2
 			function(str, lesson) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					output = $(".output", lesson)[0],
 					container = $(".container", lesson)[0],
@@ -4041,6 +4109,7 @@
 
 		<pre class="verifier">
 			function(str, lesson) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					output = $(".output", lesson)[0],
 					container = $(".container", lesson)[0],
@@ -4118,6 +4187,7 @@
 		<pre class="verifier">
 			// Combine videos and bookmarks 2
 			function(str, lesson) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")");
 				fun(jQueryMock);
 			}
@@ -4258,6 +4328,7 @@
 		<pre class="verifier">
 			// Combine videos and bookmarks 2
 			function(str, lesson) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					NOOP = function() {};
 
@@ -4396,6 +4467,7 @@
 		<pre class="verifier">
 			// Combine videos and bookmarks 2
 			function(str, lesson) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					NOOP = function() {};
 
@@ -4489,6 +4561,7 @@
 		<pre class="verifier">
 			// Combine videos and bookmarks 2
 			function(str, lesson) {
+				preVerifierHook();
 				var fun = eval("(" + str + ")"),
 					getJSON = function(url) {
 						return Observable.create(function(observer) {
@@ -4575,6 +4648,7 @@
 
         <pre class="verifier">
 			function(str, lesson) {
+				preVerifierHook();
 				var $inputName = $('.inputName', lesson),
 					$savedValue = $('.savedValue', lesson);
 
@@ -4655,7 +4729,7 @@
 
         <pre class="verifier">
 			function(str, lesson) {
-
+				preVerifierHook();
 				var wordlist = window.wordlist;
 				wordlist.sort();
 
@@ -4751,6 +4825,7 @@
 
         <pre class="verifier">
 			function(str, lesson) {
+				preVerifierHook();
 				var $inputName = $('.inputName', lesson),
 					$filtered = $('.filteredKeysByDistinct', lesson);
 
@@ -4837,7 +4912,7 @@
 
         <pre class="verifier">
 			function(str, lesson) {
-
+				preVerifierHook();
 				var wordlist = window.wordlist;
 				wordlist.sort();
 
@@ -4939,6 +5014,7 @@
 
         <pre class="verifier">
 			function(str, lesson) {
+				preVerifierHook();
 				var $inputName = $('.inputName', lesson),
 					$filtered = $('.filteredKeysByDistinct', lesson);
 


### PR DESCRIPTION
## TL;DR: 
If we don't do all the exercises in the right order, some might fail (`undefined is not a function`) due to the missing definition of 
`Array.prototype.concatAll()` and/or `Array.prototype.concatMap(function)`

## Problem
`Array.prototype.concatAll()` & `Array.prototype.concatMap(function)` are being defined in some of the exercises and added to `Array.prototype`.
For such they stay defined for the remaining time of the session.

The problem is that if we close the tab and get back in again, the session is resumed to the latest exercise completed, but this two definitions are non existent.

## Solution
We added at the beginning of each _verifier_ function a call to a `preVerifierHook` that adds the definition for `Array.prototype.concatAll()` & `Array.prototype.concatMap(function)`